### PR TITLE
Refactor initialization code out into a function pointer

### DIFF
--- a/config/micro.go
+++ b/config/micro.go
@@ -8,6 +8,10 @@ import (
 
 var configurationFile string
 
+// Builds and inits a new micro.Service object for use.  The initFunc functor being asked for will be inserted
+// into the services options as a BeforeStart which will be called DURING the service.Run invocation but BEFORE the
+// service is fully up and operational.  All of your initialization code that you need should go into this initFunc.
+// If you don't need init code then feel free to use the NilInit function exported out of this package.
 func NewService(version string, initFunc func(configuration *Configuration) error) micro.Service {
 	service := micro.NewService(
 		micro.Version(version),

--- a/config/micro_test.go
+++ b/config/micro_test.go
@@ -1,53 +1,77 @@
 package config
 
 import (
+	"errors"
 	"github.com/micro/go-micro"
+	"github.com/micro/go-micro/cmd"
+	"os"
 	"testing"
 )
 
 func TestConfiguration_NewService(t *testing.T) {
-	conf := Configuration{}
-	conf.Load("application.dist.yaml")
-	service, err := conf.NewService("1.1.1", "")
-	if _, ok := service.(micro.Service); !ok {
-		t.Errorf("service is not a micro.Service!")
-	}
-	if err != nil {
-		t.Errorf("Error not set to nil, message is: %s", err)
-	}
-}
+	os.Setenv("CONFIGURATION_FILE", "application.dist.yaml")
+	os.Args = []string{os.Args[0]}
+	cmd.DefaultCmd = cmd.NewCmd()
 
-func TestConfiguration_NewService_NoName(t *testing.T) {
-	conf := Configuration{}
-	conf.Load("application.noname.yaml")
-	service, err := conf.NewService("1.1.1", "defaultname")
+	service := NewService("1.1.1", errInit)
 	if _, ok := service.(micro.Service); !ok {
-		t.Errorf("service is not a micro.Service!")
+		t.Error("service is not a micro.Service!")
 	}
-	if err != nil {
-		t.Errorf("Error not set to nil, message is: %s", err)
-	}
-}
 
-func TestConfiguration_NewService_NoName_NoDefault(t *testing.T) {
-	conf := Configuration{}
-	conf.Load("application.noname.yaml")
-	service, err := conf.NewService("1.1.1", "")
-	if _, ok := service.(micro.Service); ok {
-		t.Errorf("service is not a micro.Service!")
-	}
+	err := service.Run()
 	if err == nil {
-		t.Errorf("Error not set to nil, message is: %s", err)
+		t.Error("Uh?  What?  I got not error?")
 	}
 }
 
 func TestConfiguration_NewService_NoConfLoaded(t *testing.T) {
-	conf := Configuration{}
-	service, err := conf.NewService("1.1.1", "")
+	os.Setenv("CONFIGURATION_FILE", "application.derp.yaml")
+	os.Args = []string{os.Args[0]}
+	cmd.DefaultCmd = cmd.NewCmd()
+	service := NewService("1.1.1", func(conf *Configuration) error { return nil })
+	err := service.Run()
 	if err == nil {
 		if _, ok := service.(micro.Service); ok {
 			t.Error("Error is nil and yet we have a valid service?")
 		}
 		t.Error("Error set to nil, at least we don't have a valid service")
 	}
+}
+
+func TestConfiguration_NewService_NilInit(t *testing.T) {
+	os.Setenv("CONFIGURATION_FILE", "application.derp.yaml")
+	os.Args = []string{os.Args[0]}
+	cmd.DefaultCmd = cmd.NewCmd()
+	service := NewService("1.1.1", NilInit)
+	err := service.Run()
+	if err == nil {
+		if _, ok := service.(micro.Service); ok {
+			t.Error("Error is nil and yet we have a valid service?")
+		}
+		t.Error("Error set to nil, at least we don't have a valid service")
+	}
+}
+
+func TestNewService_WithBlankConfigurationEnvVar(t *testing.T) {
+	os.Setenv("CONFIGURATION_FILE", "")
+	os.Args = []string{os.Args[0]}
+	cmd.DefaultCmd = cmd.NewCmd()
+	service := NewService("1.1.1", NilInit)
+	err := service.Run()
+	if err == nil {
+		t.Error("Expected an error but received nil.")
+	}
+}
+
+func TestNilInit(t *testing.T) {
+	err := NilInit(&Configuration{})
+	if err != nil {
+		t.Error("Received an error from a 1 line function that only returns nil?  What did you change and why did you change it?!?!?!  Seriously though... the name says it all... NIL INIT!! :P")
+	}
+}
+
+// For testing purposes only, I want to boot the service to ensure parsing happens but have no way to programatically stop it
+// at least not that I've found.
+func errInit(configuration *Configuration) error {
+	return errors.New("I'm supposed to fail")
 }


### PR DESCRIPTION
This takes away our ability to ensure that proper names and namespaces were set
in configuration yamls and instead pushes this stuff off into a command line argument
but the configuration never helped us anyways in the matter of ensuring things easily
bind up and find eachother so... vOv