### PR TITLE
Starting bring all potentially used micro flags into yaml

### DIFF
--- a/config/application.dist.yaml
+++ b/config/application.dist.yaml
@@ -25,3 +25,6 @@ serviceNames:
   authSrv: auth-srv
 discord:
   inviteUrl: url to be used for invitations
+registry:
+  hostname: localhost
+  port: 8500

--- a/config/config.go
+++ b/config/config.go
@@ -49,6 +49,10 @@ type Configuration struct {
 	Discord struct {
 		InviteUrl string `yaml:"inviteUrl"`
 	} `yaml:"discord"`
+	Registry struct {
+		Hostname string `yaml:"hostname"`
+		Port     int    `yaml:"port"`
+	} `yaml:"registry"`
 }
 
 func (c *Configuration) Load(filename string) error {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -73,6 +73,12 @@ func TestConfiguration_Load(t *testing.T) {
 	if conf.Discord.InviteUrl != "url to be used for invitations" {
 		t.Error("Discord.InviteUrl unset")
 	}
+	if conf.Registry.Hostname != "localhost" {
+		t.Error("Registry.Hostname unset")
+	}
+	if conf.Registry.Port == 0 {
+		t.Error("Registry.Port unset")
+	}
 }
 
 func TestConfiguration_Load_NoFile(t *testing.T) {


### PR DESCRIPTION
Configuration files other than process management configuration files
are slightly more consumable by users.  Bringing in all relevant flags
from micro into our own configuration seems useful in this regard.